### PR TITLE
Add automatic nightly release

### DIFF
--- a/.github/scripts/environment.sh
+++ b/.github/scripts/environment.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export PS3SDK=/usr/local/PSDK3v2
+export PS3DEV=$PS3SDK/ps3dev
+export PSL1GHT=$PS3SDK/psl1ght
+export PATH=$PATH:$PS3DEV/bin
+export PATH=$PATH:$PS3DEV/ppu/bin
+export PATH=$PATH:$PS3DEV/spu/bin

--- a/.github/scripts/rename.sh
+++ b/.github/scripts/rename.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+for i in *.pkg; do
+    k=$i
+    # Remove version.
+    if [[ "$i" == *"_"*".pkg"* ]]; then
+	    k="${k/"_"**".pkg"/}_nightly.pkg"
+    fi
+    # Rename file.
+    if [[ "$k" != "$i" ]]; then
+        mv "${i}" "${k}"
+    fi
+done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Nightly Release
+
+on: 
+  push
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-20.04
+    
+    container:
+      image: debian:bullseye
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install build requirements
+      run: |
+        apt-get update
+        apt-get -y install build-essential autoconf automake bison flex libelf-dev make texinfo libncurses5-dev patch python subversion wget zlib1g-dev libtool-bin python-dev bzip2 libgmp3-dev pkg-config
+
+    - name: Build release
+      run: |
+        wget --no-check-certificate https://github.com/rhynec/PSDK3v2-Linux/releases/download/v1.0/PSDK3v2.tar.gz -O PSDK3v2.tar.gz
+        tar -C /usr/local/ -xvzf PSDK3v2.tar.gz
+        . ./.github/scripts/environment.sh
+        make pkg
+        FILEMANAGER=1 make pkg
+        ./.github/scripts/rename.sh
+        
+
+    - name: Upload release
+      uses: andelf/nightly-release@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        name: 'Nightly Release'
+        prerelease: true
+        body: '- Nightly release; see commits for changes'
+        files: ./*.pkg
+


### PR DESCRIPTION
- A nightly build is now compiled after each commit (when possible).
- Build uses GitHub Actions and a re-creation of PSDK3v2 for Linux prepared and compiled by rhynec (me!).