### PR TITLE
Fix nightly workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
 
     - name: Upload release
       uses: andelf/nightly-release@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: 'Nightly-Release'
         prerelease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Build release
       run: |
-        wget --no-check-certificate https://github.com/rhynec/PSDK3v2-Linux/releases/download/v1.0/PSDK3v2.tar.gz -O PSDK3v2.tar.gz
+        wget --no-check-certificate https://github.com/rhynec/PS3SDK-Build/releases/download/2022.01.25_053310/ps3dev-psdk-bullseye.tar.gz -O PSDK3v2.tar.gz
         tar -C /usr/local/ -xvzf PSDK3v2.tar.gz
         . ./.github/scripts/environment.sh
         make pkg
@@ -31,11 +31,9 @@ jobs:
 
     - name: Upload release
       uses: andelf/nightly-release@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: 'Nightly Release'
+        name: 'Nightly-Release'
         prerelease: true
-        body: '- Nightly release; see commits for changes'
+        body: '- See commit log for included features and fixes.'
         files: ./*.pkg
 


### PR DESCRIPTION
- Switches tarball url for pre-compiled PSDK3v2 binaries (which include a small fix to ps3soundlib as well).
- Misc changes.

Note: Sorry for breaking the nightly release! I switched the repo in which the PSDK3v2 linux binaries are built, and made a couple of tweaks. The current workflow won't work since I deleted the old repo. This new repo is set up to last.