### PR TITLE
Workflow+Makefile tweaks

### DIFF
--- a/.github/scripts/name.sh
+++ b/.github/scripts/name.sh
@@ -3,7 +3,7 @@ for i in *.pkg; do
     k=$i
     # Remove version.
     if [[ "$i" == *"_"*".pkg"* ]]; then
-	    k="${k/"_"**".pkg"/}_nightly.pkg"
+	    k="${k/"_"**".pkg"/}_${TAGGY}.pkg"
     fi
     # Rename file.
     if [[ "$k" != "$i" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,22 +14,23 @@ jobs:
       run: ./.github/scripts/req.sh
     - name: Build release
       run: |
-        wget --no-check-certificate https://github.com/PS3SDK-Misc/SDK-Build/releases/download/2022.01.27_045936/psdk3-linux-bullseye.tar.gz -O psdk.tar.gz
+        wget --no-check-certificate https://github.com/PS3SDK-Misc/SDK-Build/releases/download/2022.01.29_051503/psdk3-linux-bullseye.tar.gz -O psdk.tar.gz
         tar -C /usr/local/ -xvzf psdk.tar.gz
         . ./.github/scripts/env.sh
+        export APPVER="00.50" TAIL="Nightly"
         make pkg && export FILEMANAGER=1 && make pkg
-        ./.github/scripts/name.sh
-    - name: "Re-tag nightly"
+        export TAGGY="$(date +'%y%m%d%H%M%S')" && ./.github/scripts/name.sh
+    - name: Remove previous release
       uses: dev-drprasad/delete-tag-and-release@v0.2.0
       with:
         delete_release: true
         tag_name: nightly
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Upload release assets
+    - name: Create nightly release
       uses: softprops/action-gh-release@v0.1.14
       with:
-        name: "ManaGunZ nightly"
+        name: "MGZ Nightly Releases"
         tag_name: nightly
         body: "- Non-tested nightly binaries. See commit log for included features and fixes."
         files: ./*.pkg

--- a/Makefile
+++ b/Makefile
@@ -34,19 +34,20 @@ PKGFILES1	:=	$(CURDIR)/pkgfiles
 PKGFILES2	:=	$(CURDIR)/pkgfiles2
 SFOXML		:=	sfo.xml
 
-VERSION		:=  1.41
+APPVER		?=	01.41
+TAIL		?=	
 
 ifeq ($(FILEMANAGER), 1)
 PKGFILES	:=	$(PKGFILES2)
-MACHDEP		+= -DFILEMANAGER
+MACHDEP		+=	-DFILEMANAGER
 TARGET		:=	FileManager
-TITLE		:=	File Manager v$(VERSION)
-APPID		:=	FILEMANAG
+TITLE		:=	$(TARGET) $(TAIL)
+APPID		?=	FILEMANAG
 else
 PKGFILES	:=	$(PKGFILES1)
 TARGET		:=	ManaGunZ
-TITLE		:=	$(TARGET) v$(VERSION)
-APPID		:=	MANAGUNZ0
+TITLE		:=	$(TARGET) $(TAIL)
+APPID		?=	MANAGUNZ0
 endif
 CONTENTID	:=	EP0001-$(APPID)_00-0000000000000000
 
@@ -71,7 +72,7 @@ LIBS	:=
 # list of directories containing libraries, this must be the top level containing
 # include and lib
 #---------------------------------------------------------------------------------
-LIBDIRS	:= $(PORTLIBS)
+LIBDIRS	:=	$(PORTLIBS)
 
 #---------------------------------------------------------------------------------
 # no real need to edit anything past this point unless you need to add additional
@@ -80,7 +81,7 @@ LIBDIRS	:= $(PORTLIBS)
 ifneq ($(BUILD),$(notdir $(CURDIR)))
 #---------------------------------------------------------------------------------
 
-export OUTPUT	:=	$(CURDIR)/$(TARGET)_v$(VERSION)
+export OUTPUT	:=	$(CURDIR)/$(TARGET)_v$(APPVER)
 
 export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
 					$(foreach dir,$(DATA),$(CURDIR)/$(dir))
@@ -136,7 +137,7 @@ export INCLUDE	:=	-I$(PORTLIBS)/include/freetype2 \
 export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) \
 					$(LIBPSL1GHT_LIB)
 
-export OUTPUT	:=	$(CURDIR)/$(TARGET)_v$(VERSION)
+export OUTPUT	:=	$(CURDIR)/$(TARGET)_v$(APPVER)
 .PHONY: $(BUILD) clean
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
- Makefile modified to not include app version in filename/title. Instead, APPVER variable is defined which will set APP_VER in the generated SFO using PSDK3v2-Linux.
- Workflow updated to reflect makefile changes + tarball link update.
- In nightly workflow, nighly releases now have in their filename the date/time of release, and their title in the SFO file includes the label "Nighly".
- Nighlty release no longer tied to a specific release, uses 00.50 as APP_VER.

Note: This PR is mainly a draft. While the tweaks to the makefile were mostly made to polish the nightly release, I've also changed the way the app's TITLE and APP_VER are set. The version indicator for MGZ is moved to the sfo, and sfo.py (on PSDK3v2-Linux) has been tweaked to accept the APPVER variable for this purpose. For your local machine, modifying the ppu_rules with the changes from [this](https://github.com/PSDK3v2-Linux/PSL1GHT/commit/7e104740d8252664160bf3c83d0e796aff4dd78f) commit, and also copying the sfo.py, should add this feature. Though, since this changes the naming scheme MGZ has alwyas used, feel free to tweak this PR to your liking, or only use it as reference for later.